### PR TITLE
Fix notices for each non listed project

### DIFF
--- a/traces
+++ b/traces
@@ -413,7 +413,7 @@ function fetchConfiguration(string $file): array {
                 $section = array_reduce(array_keys(REPOSITORIES_CATEGORIES), function($carry, $item) use ($repository) {
                     return in_array($repository, REPOSITORIES_CATEGORIES[$item]) ? $item : $carry;
                 }, 'others');
-                
+
                 $contributors = fetchRepositoryContributors($client, $authHeaders, $repository);
                 foreach ($contributors as $contributor) {
                     $keyUsers = $contributor['login'];
@@ -453,6 +453,9 @@ function fetchConfiguration(string $file): array {
                     $users[$keyUsers]['contributions'] += $contributor['contributions'];
                     $users[$keyUsers]['repositories'][$repository] = $contributor['contributions'];
                     $users[$keyUsers]['categories'][$section]['total'] += $contributor['contributions'];
+                    if(!array_key_exists($repository, $users[$keyUsers]['categories'][$section]['repositories'])) {
+                        $users[$keyUsers]['categories'][$section]['repositories'][$repository] = 0;
+                    }
                     $users[$keyUsers]['categories'][$section]['repositories'][$repository] += $contributor['contributions'];
                 }
                 $io->progressAdvance();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Remove the notice of undefined index when parsing a repo which is not in the config array. This does not fix a bug as php create the index anyway on the fly.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | NA
| How to test?      | Run => No more notices \o/
| Possible impacts? | NA

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
