### PR TITLE
Remove `devops-prestashop` from contributors

### DIFF
--- a/config.dist.yml
+++ b/config.dist.yml
@@ -19,6 +19,7 @@ config:
     - dependabot[bot]
     - dependabot-preview
     - dependabot-preview[bot]
+    - devops-prestashop
     - gitbook-bot
     - ps-jarvis
     - github-actions[bot]


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Remove `devops-prestashop` from contributors because I think it's a bot.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | @Creabilis
| How to test?      | `devops-prestashop` should no longer appear in contributors list.
