### PR TITLE
feat(company): serialize employees timeframes to topcompanies_prs.json

### DIFF
--- a/src/DTO/Company.php
+++ b/src/DTO/Company.php
@@ -58,7 +58,7 @@ class Company
     }
 
     /**
-     * @return array<string, array<int|string, int>|float|int|string|string[]>
+     * @return array<string, mixed>
      */
     public function toArray(bool $rankByContributions): array
     {
@@ -79,6 +79,17 @@ class Company
             'avatar_url' => $this->avatarUrl,
             'html_url' => $this->htmlUrl,
             'contributors' => array_values(array_unique($this->contributors)),
+            'employees' => array_map(function (Employee $employee): array {
+                return [
+                    'login' => $employee->login,
+                    'time_frames' => array_map(function (TimeFrame $timeFrame): array {
+                        return [
+                            'start_date' => $timeFrame->startTime->format('Y-m-d'),
+                            'end_date' => $timeFrame->endTime?->format('Y-m-d'),
+                        ];
+                    }, $employee->timeFrames),
+                ];
+            }, $this->employees),
         ];
     }
 }


### PR DESCRIPTION
## Summary

- `Company::toArray()` now embeds the full `employees` map — `login → [{ start_date, end_date }, …]` — sourced from `var/data/companies.json`.
- Traces already loaded this data to attribute each merged PR to the company employing the author at merge time; it just was never propagated to the JSON consumed by the front. Publishing it lets the front render a proper members table (entry/departure per period, still-active flag, multiple periods per person) instead of relying on the ad-hoc `contributors` list, which is the derived set of PR authors — a different, noisier population.
- The `toArray()` docblock is widened to `array<string, mixed>` because the shape now nests `employees[].time_frames[]`. phpstan (level max) is green on `src/DTO/Company.php`, and callers only consume the array via `json_encode`.

## Test plan

- [x] `vendor/bin/phpstan analyse src/DTO/Company.php --level=max` → No errors.
- [x] `php bin/console traces:generate:topcompanies` → `topcompanies_prs.json` regenerated successfully; PrestaShop entry now carries `employees` (69 entries) alongside the pre-existing `contributors` (85 entries).
- [x] Sample serialization matches the input:
      ```json
      { "login": "0x346e3730", "time_frames": [{ "start_date": "2022-10-03", "end_date": "2023-06-30" }] }
      ```
- [ ] Downstream front (TopContributors) consumes the new field to render a per-employee table with periods, tenure, and Active/Left status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)