### PR TITLE
feat(company): expose separate github_url field

### DIFF
--- a/src/Command/GenerateTopCompaniesCommand.php
+++ b/src/Command/GenerateTopCompaniesCommand.php
@@ -126,6 +126,7 @@ class GenerateTopCompaniesCommand extends AbstractCommand
                 $employees,
                 $companyData['avatar_url'] ?? '',
                 $companyData['html_url'] ?? '',
+                $companyData['github_url'] ?? null,
             );
         }
 

--- a/src/DTO/Company.php
+++ b/src/DTO/Company.php
@@ -45,6 +45,7 @@ class Company
         public readonly array $employees,
         public readonly string $avatarUrl,
         public readonly string $htmlUrl,
+        public readonly ?string $githubUrl = null,
     ) {
         $this->slug = self::slugify($this->name);
     }
@@ -78,6 +79,7 @@ class Company
             'contributions_percent' => $this->contributionsPercent,
             'avatar_url' => $this->avatarUrl,
             'html_url' => $this->htmlUrl,
+            'github_url' => $this->githubUrl,
             'contributors' => array_values(array_unique($this->contributors)),
             'employees' => array_map(function (Employee $employee): array {
                 return [

--- a/var/data/companies.json
+++ b/var/data/companies.json
@@ -1087,6 +1087,7 @@
   {
     "name": "PrestaEdit",
     "html_url": "https://prestaedit.com/",
+    "github_url": "https://github.com/PrestaEdit",
     "avatar_url": "https://avatars.githubusercontent.com/u/2631425",
     "aliases": [
       "@PrestaEdit",


### PR DESCRIPTION
## Summary
- Add optional `github_url` field to the Company DTO and its serialized output in `topcompanies_prs.json`.
- Read the new field from `var/data/companies.json` in `GenerateTopCompaniesCommand`.
- Populate it for PrestaEdit as a first example.

## Motivation
`html_url` on a company entry points to the company's **website**, not to GitHub. The front (TopContributors) currently renders it under a "GitHub" label on the company detail page, which is misleading. This change lets us surface both links cleanly (Website + GitHub) on the front sidebar.

The front-side change lives in a companion PR on TopContributors: it renders `github_url` as the GitHub link and keeps `html_url` as the Website link.

## Test plan
- [ ] Regenerate `topcompanies_prs.json` and verify PrestaEdit exposes both `html_url` and `github_url`.
- [ ] Verify companies without `github_url` in the source still generate a valid entry (field is `null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)